### PR TITLE
Working German Translation

### DIFF
--- a/jsons/translations/German.properties
+++ b/jsons/translations/German.properties
@@ -14,7 +14,7 @@ Can only be built to improve a resource = Kann nur gebaut werden, um eine Resour
  # Requires translation!
 Cannot be built on [tileFilter] tiles = Kann nicht auf [tileFilter] Feldern gebaut werden
  # Requires translation!
-Pillaging this improvement yields approximately [stats] = Plünderung dieser Verbesserung gibt ungef&auml;hr [stats]
+Pillaging this improvement yields approximately [stats] = Plünderung dieser Verbesserung gibt ungefähr [stats]
 
 
 #################### Lines from TileResources ####################
@@ -25,7 +25,7 @@ Capybara = Capybara
  # Requires translation!
 Pigs = Schweine
 
-Chickens = H&uuml;hner
+Chickens = Hühner
 
  # Requires translation!
 Bulls = Stiere
@@ -58,19 +58,19 @@ Corn = Mais
 Avocados = Avocados
 
  # Requires translation!
-Apples = &Auml;pfel
+Apples = Äpfel
 
  # Requires translation!
-Pumpkins = K&uuml;rbisse
+Pumpkins = Kürbisse
 
  # Requires translation!
 Watermelons = Melonen
 
  # Requires translation!
-Coconuts = Kokosn&uuml;sse
+Coconuts = Kokosnüsse
 
  # Requires translation!
-Oils = &Ouml;le
+Oils = Öle
 
  # Requires translation!
 Mango = Mango


### PR DESCRIPTION
I didnt know the translations file accepts "Umlaute" (ä,ö,ü)
Now I  fixed it